### PR TITLE
Removing the license section

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
       <p>Becoming an owner should not come with the pressure to maintain the project for longer than you have interest. This should encourage people to accept ownership, even if for a short time.</p>
       <p>Owners of Rackt projects can stop working on them without any guilt or explanation, just like a job.  If this makes you uncomfortable, you can either not use Rackt projects or, preferably, increase your organizations investment in open source and dedicate some time to helping with maintenance. If you use our code, it is now <em>our</em> code. (Get it yet?)</p>
 
-      <h3><a id="avoid-burnout" href="#avoid-burnout">4) Avoid Burnout</a></h3>
+      <h3><a id="avoid-burnout" href="#avoid-burnout">3) Avoid Burnout</a></h3>
       <p>The first priority in managing the issue tracker for a Rackt project is avoiding burnout. Sprawling lists of inactionable, open issues, is burnout’s most potent fuel.</p>
 
       <p>This means:</p>

--- a/index.html
+++ b/index.html
@@ -57,9 +57,6 @@
       <p>Becoming an owner should not come with the pressure to maintain the project for longer than you have interest. This should encourage people to accept ownership, even if for a short time.</p>
       <p>Owners of Rackt projects can stop working on them without any guilt or explanation, just like a job.  If this makes you uncomfortable, you can either not use Rackt projects or, preferably, increase your organizations investment in open source and dedicate some time to helping with maintenance. If you use our code, it is now <em>our</em> code. (Get it yet?)</p>
 
-      <h3><a id="os-license" href="#os-license">3) Code has Non-Profit Ownership, MIT/ISC License</a></h3>
-      <p>Code on Rackt must be owned by a non-profit and have the <a href="https://opensource.org/licenses/MIT">MIT</a> or <a href="https://opensource.org/licenses/ISC">ISC</a> license. This ensures that the owners of a project can continue to maintain it regardless of corporate acquisitions and bureaucracy.</p>
-
       <h3><a id="avoid-burnout" href="#avoid-burnout">4) Avoid Burnout</a></h3>
       <p>The first priority in managing the issue tracker for a Rackt project is avoiding burnout. Sprawling lists of inactionable, open issues, is burnout’s most potent fuel.</p>
 


### PR DESCRIPTION
With the merge of the org, there are repos that are under Facebook BSD license which is not MIT/ISC nor owned by a non-profit (Facebook). I believe that "the owners of a project can continue to maintain it" is mostly true, regardless of the license of acquisitions. The problem usually come when the owners leave and the project is left to an uncertain future.